### PR TITLE
feat: add Next.js site with CMS integration

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,2 @@
+CONTENTFUL_SPACE_ID=your_space_id
+CONTENTFUL_ACCESS_TOKEN=your_access_token

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env.local

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# TEST1
-testare github obisnuire
+# Prop Firms Promotions Next.js Site
+
+Acest proiect este un exemplu de site dinamic realizat cu Next.js care afișează promoțiile unor prop firms. Datele sunt preluate din Contentful (un CMS headless).
+
+## Configurare
+
+1. Copiază fișierul `.env.local.example` în `.env.local` și completează valorile pentru:
+   - `CONTENTFUL_SPACE_ID`
+   - `CONTENTFUL_ACCESS_TOKEN`
+2. Instalează dependențele:
+   ```bash
+   npm install
+   ```
+3. Rulează în dezvoltare:
+   ```bash
+   npm run dev
+   ```
+
+## Testare
+
+Scriptul de testare folosește Jest:
+```
+npm test
+```
+
+În lipsa dependențelor instalate, comenzile de mai sus vor eșua; asigură-te că ai acces la internet și permisiunea de a descărca pachetele necesare.

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -1,0 +1,41 @@
+const SPACE = process.env.CONTENTFUL_SPACE_ID;
+const ACCESS_TOKEN = process.env.CONTENTFUL_ACCESS_TOKEN;
+
+export async function fetchPropFirms() {
+  if (!SPACE || !ACCESS_TOKEN) {
+    console.warn('Contentful credentials are missing');
+    return [];
+  }
+
+  const query = `
+    {
+      propFirmCollection {
+        items {
+          name
+          promoText
+          affiliateLink
+        }
+      }
+    }
+  `;
+
+  const res = await fetch(
+    `https://graphql.contentful.com/content/v1/spaces/${SPACE}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${ACCESS_TOKEN}`,
+      },
+      body: JSON.stringify({ query }),
+    }
+  );
+
+  if (!res.ok) {
+    console.error('Failed to fetch from Contentful', res.statusText);
+    return [];
+  }
+
+  const json = await res.json();
+  return json?.data?.propFirmCollection?.items ?? [];
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "prop-firms-next",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "jest"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "jest": "29.7.0"
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,27 @@
+import { fetchPropFirms } from '../lib/contentful';
+
+export default function Home({ firms }) {
+  return (
+    <main>
+      <h1>Promoții Prop Firms</h1>
+      {firms.length === 0 && <p>Nicio promoție disponibilă.</p>}
+      {firms.map((firm) => (
+        <div key={firm.name} className="firm">
+          <h2>{firm.name}</h2>
+          <p>Promoție: {firm.promoText}</p>
+          <a href={firm.affiliateLink} target="_blank" rel="noopener noreferrer">
+            Vezi oferta &rarr;
+          </a>
+        </div>
+      ))}
+    </main>
+  );
+}
+
+export async function getStaticProps() {
+  const firms = await fetchPropFirms();
+  return {
+    props: { firms },
+    revalidate: 60,
+  };
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js project for prop firm promotions
- integrate Contentful CMS via GraphQL fetch
- document environment setup and commands

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*
- `npm test` *(fails: jest: not found)*
- `npm run build` *(fails: next: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898e02a73388328a95f6fc21339c89e